### PR TITLE
Draft : Remove stopwords and generate a test csv file

### DIFF
--- a/python/helper/tokenize_resume.py
+++ b/python/helper/tokenize_resume.py
@@ -1,0 +1,29 @@
+# This code is used to create a test csv file
+# The csv file contains tokens in Token column returned from pdf2Token function form pdf2Token.py for a given input resume 
+# The csv file contains Job_cat column which is placeholder to describe the resume category against its tokenized list of words
+# output: python/resources/tokenized_resumes.csv
+
+import pandas as pd
+from pdf2Token import pdf2Token
+
+def tokenize_resume(filepath: str):
+
+    # Call pdf2Token function with resume filepath argument to get list of tokens
+    tokens = pdf2Token(str)
+
+    # Sample data (you should replace this with your actual data)
+    data = {
+        "Tokens": [tokens],
+        "Job_cat": ["Software Developement Sample"]
+    }
+
+    # Create the DataFrame
+    tokenized_resume = pd.DataFrame(data)
+
+    # export as a csv
+    tokenized_resume.to_csv("../resources/tokenized_resumes.csv", index=False)
+
+    # Use this csv contained tokenized list of sample resume for testing
+    print("DataFrame exported to 'python/resources/tokenized_resume.csv'")
+
+    return

--- a/python/remove_stopwords.py
+++ b/python/remove_stopwords.py
@@ -1,0 +1,37 @@
+# This code removes all stopwords for a list of tokens
+# It reads a csv file provided as input argument that contains a tokenized list of words from a resume generated using pdf2Token function
+# It then removes all stopwords using recognized stopwords for English langaues from NLTK library
+# The list of token without stopword are stored into a new csv file 
+# output: python/resources/stopword_removed_tokens.csv
+
+import os
+import pandas as pd
+import nltk
+from nltk.corpus import stopwords
+
+# Function to remove stop words from a list of tokens
+def get_stopword_removed_list(token_list):
+    stop_words = set(stopwords.words('english'))
+    return [token for token in token_list if token.lower() not in stop_words]
+
+def remove_stopwords(csv_filepath: str):
+
+    # Check the input CSV filepath for a correct csv file input
+    if not csv_filepath.endswith('.csv') or not os.path.isfile(csv_filepath):
+        raise Exception(f"{csv_filepath} is not a valid CSV file")
+
+    # Download NLTK stopwords
+    nltk.download('stopwords')
+
+    # Load the CSV file into a DataFrame
+    df = pd.read_csv('your_file.csv')
+
+    # Apply the get_stopword_removed_list function to the "Token" column
+    df['Token'] = df['Token'].apply(get_stopword_removed_list)
+
+    # Save the updated Token column DataFrame to a CSV file
+    df.to_csv("../resources/stopword_removed_tokens.csv", index=False)
+
+    print("DataFrame exported to 'python/resources/stopword_removed_tokens.csv' with stopwords removed")
+
+    return


### PR DESCRIPTION
Added two functions
- remove_stopwords : read a csv file and removed stopwords for list of tokens in Token column and store results in a new csv file called python/resources/stopword_removed_tokens.csv
- tokenize_resume : takes in sample resume filepath and generates a csv file with tokenized list of words obtained from pdf2tokens function implemented in #5 